### PR TITLE
fix: 更换 setup 文档中 pcre 的下载地址（原地址失效）

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -26,7 +26,7 @@ cd $(mktemp -d)
 curl -O https://www.openssl.org/source/openssl-1.1.1b.tar.gz
 tar zxf openssl-*
 
-curl -O https://ftp.pcre.org/pub/pcre/pcre-8.43.tar.gz
+curl -O https://ftp.exim.org/pub/pcre/pcre-8.43.tar.gz
 tar zxf pcre-*
 
 curl -O https://zlib.net/zlib-1.2.11.tar.gz


### PR DESCRIPTION
```
$ curl -O https://ftp.pcre.org/pub/pcre/pcre-8.43.tar.gz
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
  0     0    0     0    0     0      0      0 --:--:-- --:--:-- --:--:--     0curl: (6) Could not resolve host: ftp.pcre.org
```

```
$ nslookup ftp.pcre.org 8.8.8.8
Server:		8.8.8.8
Address:	8.8.8.8#53

** server can't find ftp.pcre.org: NXDOMAIN
```

通过以上测试可知，ftp.pcre.org 域名已经失效。因此替换了 pcre 的下载路径。